### PR TITLE
fix(deps): patch Dependabot alerts in RN demo app Gemfiles

### DIFF
--- a/react-native/MSSDKDemoApp-ReactNative/MSSDKDemoAppRN/Gemfile
+++ b/react-native/MSSDKDemoApp-ReactNative/MSSDKDemoAppRN/Gemfile
@@ -16,3 +16,7 @@ gem 'bigdecimal'
 gem 'logger'
 gem 'benchmark'
 gem 'mutex_m'
+# nkf (provides kconv) was removed from the default gems in Ruby 3.4+; CocoaPods'
+# CFPropertyList path needs it, otherwise `pod install` fails on Ruby 4 with
+# "LoadError: cannot load such file -- kconv".
+gem 'nkf'

--- a/react-native/MSSDKDemoApp-ReactNative/MSSDKDemoAppRN/Gemfile
+++ b/react-native/MSSDKDemoApp-ReactNative/MSSDKDemoAppRN/Gemfile
@@ -1,13 +1,15 @@
 source 'https://rubygems.org'
 
-# You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby ">= 2.6.10"
+# You may use http://rbenv.org/ or https://rvm.io/ to install and use this version.
+# activesupport >= 7.2 requires Ruby >= 3.1.
+ruby ">= 3.1"
 
-# Exclude problematic versions of cocoapods and activesupport that causes build failures.
+# Exclude cocoapods versions with known build failures, and pin activesupport and
+# concurrent-ruby to versions that patch known CVEs.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
-gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+gem 'activesupport', '>= 7.2.3.1'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '< 1.3.4'
+gem 'concurrent-ruby', '>= 1.3.7'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'

--- a/react-native/MomentsAPIDemoApp/Gemfile
+++ b/react-native/MomentsAPIDemoApp/Gemfile
@@ -1,9 +1,11 @@
 source 'https://rubygems.org'
 
-# You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby ">= 2.6.10"
+# You may use http://rbenv.org/ or https://rvm.io/ to install and use this version.
+# activesupport >= 7.2 requires Ruby >= 3.1.
+ruby ">= 3.1"
 
 # Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
 # bound in the template on Cocoapods with next React Native release.
 gem 'cocoapods', '>= 1.13', '< 1.15'
-gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
+# Pin activesupport to a version that patches known CVEs (>= 7.2.3.1).
+gem 'activesupport', '>= 7.2.3.1'

--- a/react-native/MomentsAPIDemoApp/Gemfile
+++ b/react-native/MomentsAPIDemoApp/Gemfile
@@ -4,8 +4,11 @@ source 'https://rubygems.org'
 # activesupport >= 7.2 requires Ruby >= 3.1.
 ruby ">= 3.1"
 
-# Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
-# bound in the template on Cocoapods with next React Native release.
+# CocoaPods 1.15 introduced a build-breaking bug; remove this upper bound in the
+# template with the next React Native release.
 gem 'cocoapods', '>= 1.13', '< 1.15'
-# Pin activesupport to a version that patches known CVEs (>= 7.2.3.1).
+# Pin activesupport and concurrent-ruby to versions that patch known CVEs.
+# activesupport >= 7.2.3.1 only requires concurrent-ruby >= 1.3.1, so pin the
+# concurrent-ruby security floor (>= 1.3.7) explicitly, matching the other apps.
 gem 'activesupport', '>= 7.2.3.1'
+gem 'concurrent-ruby', '>= 1.3.7'

--- a/react-native/PerkswallEmbeddedRN/Gemfile
+++ b/react-native/PerkswallEmbeddedRN/Gemfile
@@ -1,10 +1,12 @@
 source 'https://rubygems.org'
 
-# You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby ">= 2.6.10"
+# You may use http://rbenv.org/ or https://rvm.io/ to install and use this version.
+# activesupport >= 7.2 requires Ruby >= 3.1.
+ruby ">= 3.1"
 
-# Exclude problematic versions of cocoapods and activesupport that causes build failures.
+# Exclude cocoapods versions with known build failures, and pin activesupport and
+# concurrent-ruby to versions that patch known CVEs.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
-gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+gem 'activesupport', '>= 7.2.3.1'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '< 1.3.4'
+gem 'concurrent-ruby', '>= 1.3.7'

--- a/react-native/PerkswallEmbeddedRN/Gemfile
+++ b/react-native/PerkswallEmbeddedRN/Gemfile
@@ -10,3 +10,8 @@ gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 7.2.3.1'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '>= 1.3.7'
+
+# nkf (provides kconv) was removed from the default gems in Ruby 3.4+; CocoaPods'
+# CFPropertyList path needs it, otherwise `pod install` fails on Ruby 4 with
+# "LoadError: cannot load such file -- kconv".
+gem 'nkf'


### PR DESCRIPTION
## What

Resolves the **15 open Dependabot alerts** on this repo, all in the Ruby/CocoaPods build toolchain of the three React Native demo apps (`MomentsAPIDemoApp`, `PerkswallEmbeddedRN`, `MSSDKDemoAppRN`).

The alerts came down to two packages whose version pins were holding the fixes back:

| Package | Before | After | Fixes |
|---|---|---|---|
| `activesupport` | `< 7.1.0` / `!= 7.1.0` | `>= 7.2.3.1` | DoS, XSS (`SafeBuffer#%`), ReDoS (`number_to_delimited`) |
| `concurrent-ruby` | `< 1.3.4` | `>= 1.3.7` | **High**: `AtomicReference#update` livelock + 2 `ReadWriteLock` advisories |

Also:
- Bumped the Ruby floor `>= 2.6.10` → `>= 3.1` (required by activesupport 7.2).
- Refreshed the now-stale `# Exclude problematic versions...` comments.

## Why the pins existed

Those upper bounds were RN-template workarounds for build breakage — notably the activesupport 7.1 load-time crash in CocoaPods and the `concurrent-ruby` 1.3.4 `logger` removal. Both are resolved in the target versions (1.3.7+ restores `logger`; CocoaPods loads fine on activesupport 7.2).

## Verification

- All three Gemfiles resolve cleanly → `activesupport 7.2.3.1`, `concurrent-ruby 1.3.8`.
- Installed the full bundle for `MomentsAPIDemoApp` (the one pinned to `cocoapods < 1.15`) and confirmed **CocoaPods 1.14.3 installs and loads successfully** on the new dependency set — exercising the exact load-time path the old pins guarded.

## Caveats

- Verified `bundle install` + CocoaPods load, **not** a full `pod install` + native Xcode build per app.
- Note the lockfiles are `.gitignore`d, so the fix lives in the `Gemfile` constraints. **CI/contributors must be on Ruby 3.1+.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
  - Updated the React Native demo projects to require Ruby 3.1 or newer.
  - Improved Ruby/ActiveSupport compatibility by adjusting dependency constraints to match current platform requirements.

- **Maintenance**
  - Updated supporting Ruby packages (ActiveSupport and concurrent-ruby) to newer minimum versions for stability and security.
  - Added `nkf` to ensure CocoaPods installs work reliably on newer Ruby versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->